### PR TITLE
Create `get_stats` member function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(GTest REQUIRED)
 
 add_executable(test_rangeset
  "rangeset.h"
+ "rangesizeset.h"
  "test_insert.cpp"
  "test_iterate.cpp"
  "test_erase.cpp"
@@ -19,6 +20,7 @@ add_executable(test_rangeset
  "test_lookup_size.cpp"
  "test_swap.cpp"
  "test_swap_size.cpp"
+ "test_get_stats.cpp"
 )
 
 target_link_libraries(

--- a/rangesizeset.h
+++ b/rangesizeset.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <map>
 #include <type_traits>
+#include <utility>
 
 namespace HyoutaUtilities {
 // Like RangeSet, but additionally stores a map of the ranges sorted by their size, for quickly finding the largest or
@@ -396,6 +397,16 @@ public:
 
   bool operator!=(const RangeSizeSet<T>& other) const {
     return !(*this == other);
+  }
+
+  // Get free size and fragmentation ratio
+  std::pair<std::size_t, double> get_stats() const {
+    std::size_t free_total = 0;
+    if (begin() == end())
+      return {free_total, 1.0};
+    for (auto iter = begin(); iter != end(); ++iter)
+      free_total += calc_size(iter.from(), iter.to());
+    return {free_total, static_cast<double>(free_total - Sizes.begin()->first) / free_total};
   }
 
 private:

--- a/test_get_stats.cpp
+++ b/test_get_stats.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include "rangeset.h"
+#include "rangesizeset.h"
+
+TEST(GetStatsTest, RangeSet) {
+  HyoutaUtilities::RangeSet<std::size_t> rs;
+  rs.insert(0, 100);
+
+  ASSERT_TRUE((rs.get_stats() == std::pair{std::size_t{100}, 0.0}));
+  rs.erase(10, 20);
+  ASSERT_TRUE((rs.get_stats() == std::pair{std::size_t{90}, 10.0 / 90}));
+  rs.erase(40, 50);
+  ASSERT_TRUE((rs.get_stats() == std::pair{std::size_t{80}, (10.0 + 20.0) / 80}));
+  rs.erase(20, 40);
+  rs.erase(0, 10);
+  ASSERT_TRUE((rs.get_stats() == std::pair{std::size_t{50}, 0.0}));
+}
+
+TEST(GetStatsTest, RangeSizeSet) {
+  HyoutaUtilities::RangeSizeSet<std::size_t> rs;
+  rs.insert(0, 100);
+
+  ASSERT_TRUE((rs.get_stats() == std::pair{std::size_t{100}, 0.0}));
+  rs.erase(10, 20);
+  ASSERT_TRUE((rs.get_stats() == std::pair{std::size_t{90}, 10.0 / 90}));
+  rs.erase(40, 50);
+  ASSERT_TRUE((rs.get_stats() == std::pair{std::size_t{80}, (10.0 + 20.0) / 80}));
+  rs.erase(20, 40);
+  rs.erase(0, 10);
+  ASSERT_TRUE((rs.get_stats() == std::pair{std::size_t{50}, 0.0}));
+}


### PR DESCRIPTION
This new member function for RangeSet and RangeSizeSet is used to query the free size and fragmentation ratio of a range set. This functionality is useful for https://github.com/dolphin-emu/dolphin/pull/12714.